### PR TITLE
fix: implement Abs expectation over Normal

### DIFF
--- a/src/ClosedFormExpectations.jl
+++ b/src/ClosedFormExpectations.jl
@@ -47,6 +47,7 @@ include("expressions/Product.jl")
 include("expressions/Square.jl")
 include("expressions/Power.jl")
 include("expressions/xlog2x.jl")
+include("expressions/Abs.jl")
 
 # rules for computing expectation of log
 include("Exponential/Exponential.jl")

--- a/src/Normal/UnivariateNormal.jl
+++ b/src/Normal/UnivariateNormal.jl
@@ -14,3 +14,8 @@ function mean(::ClosedFormExpectation, p::Logpdf{Laplace{T}}, q::GaussianDistrib
     diff = μ_p - μ_q
     return - log(2*θ_p) - θ_p^(-1) * ( 2 * (σ_q/sqrt(2*π)) * exp(-diff^2/(2*σ_q^2))  +  diff * (2 * cdf(normal,diff) - 1) )
 end 
+
+function mean(::ClosedFormExpectation, f::Abs, q::GaussianDistributionsFamily)
+    μ, σ = mean(q), std(q)
+    return μ*erf(μ/(sqrt(2)*σ)) + sqrt(2/π)*std(q)*exp(-μ^2/(2*σ^2))
+end

--- a/src/Normal/UnivariateNormal.jl
+++ b/src/Normal/UnivariateNormal.jl
@@ -1,5 +1,6 @@
 import Distributions: Laplace, Normal, Rayleigh, params, cdf, std
 import ExponentialFamily: GaussianDistributionsFamily
+using SpecialFunctions: erf
 
 function mean(::ClosedFormExpectation, p::Logpdf{NormalType}, q::GaussianDistributionsFamily) where {NormalType <: GaussianDistributionsFamily}
     μ_q, σ_q = mean(q), std(q)

--- a/src/expressions/Abs.jl
+++ b/src/expressions/Abs.jl
@@ -1,0 +1,13 @@
+export Abs
+
+"""
+    Abs{T}
+
+The absolute value of a number: |x|.
+"""
+
+struct Abs <: Expression end
+
+function (f::Abs)(x)
+    return abs(x)
+end

--- a/test/Normal/mean_test.jl
+++ b/test/Normal/mean_test.jl
@@ -26,3 +26,26 @@ end
         central_limit_theorem_test(ClosedFormExpectation(), Logpdf(Laplace(μ_2, θ)), Normal(μ_1, σ))
     end
 end
+
+@testitem "mean(::ClosedFormExpectation, ::Abs, ::Normal)" begin
+    using Distributions
+    using ClosedFormExpectations
+    using StableRNGs
+
+    include("../test_utils.jl")
+    rng = StableRNG(123)
+    for _ in 1:10
+        μ, σ = rand(rng)*10, rand(rng)*5
+        value = mean(ClosedFormExpectation(), Abs(), Normal(μ, σ))
+        central_limit_theorem_test(ClosedFormExpectation(), Abs(), Normal(μ, σ))
+    end
+
+    @testset "compare with laplace" begin
+        μ, σ = rand(rng)*10, rand(rng)*5
+        θ = rand(rng)*10
+        value = mean(ClosedFormExpectation(), Abs(), Normal(μ, σ))
+        value_laplace = mean(ClosedFormExpectation(), Logpdf(Laplace(0, θ)), Normal(μ, σ))
+        @test log(0.5*1/θ) - 1/θ * value ≈ value_laplace
+    end
+    
+end


### PR DESCRIPTION
This PR adds `mean(::ClosedFormExpectation, f::Abs, q::GaussianDistributionsFamily)`