### PR TITLE
Remove unnecessary run command from CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,8 +38,7 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-      - run: DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24' julia --project=@. -e 'using Pkg; Pkg.test(coverage=true)'
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         env:
-            CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow by removing a redundant or unnecessary test command. The main test step is already being handled by the `julia-actions/julia-runtest@v1` action, so the explicit `xvfb-run` command has been removed to streamline the workflow.

- Removed the redundant `xvfb-run` command that manually ran Julia tests with coverage, as test execution is already managed by `julia-actions/julia-runtest@v1` in `.github/workflows/CI.yml`.